### PR TITLE
Fix for Xcode 10.1

### DIFF
--- a/bezier-paths.playground/Pages/Starting.xcplaygroundpage/Contents.swift
+++ b/bezier-paths.playground/Pages/Starting.xcplaygroundpage/Contents.swift
@@ -281,7 +281,7 @@ class BezierViewController : UIViewController {
             
         case .changed:
             guard let p = dragPoint else { return }
-            bezierView[keyPath: p.keyPath] = recognizer.location(in: bezierView)
+            bezierView[keyPath: p.keyPath] = recognizer.location(in: bezierView) as CGPoint?
             
         case .cancelled, .ended:
             dragPoint = nil


### PR DESCRIPTION
The pan recogniser CGPoint must be cast as optional in order to satisfy compiler